### PR TITLE
*: allow building wal with GOARCH=wasm GOOS=wasip1

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -15,7 +15,13 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.20'
+        go-version: '1.22'
 
     - name: Test
       run: go test -v ./...
+
+    - name: Set up wasmtime
+      uses: bytecodealliance/actions/wasmtime/setup@v1
+
+    - name: Test WASM
+      run: PATH=$PATH:$(go env GOROOT)/misc/wasm GOOS=wasip1 GOARCH=wasm go test ./...

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/polarsignals/wal/types"
 )
 
@@ -60,7 +59,8 @@ func (fs *FS) Create(dir string, name string, size uint64) (types.WritableFile, 
 		if size > math.MaxInt32 {
 			return nil, fmt.Errorf("maximum file size is %d bytes", math.MaxInt32)
 		}
-		if err := fileutil.Preallocate(f, int64(size), true); err != nil {
+
+		if err := prealloc(f, int64(size), true); err != nil {
 			f.Close()
 			return nil, err
 		}
@@ -112,17 +112,4 @@ func (fs *FS) OpenReader(dir string, name string) (types.ReadableFile, error) {
 // corrupt in arbitrary ways.
 func (fs *FS) OpenWriter(dir string, name string) (types.WritableFile, error) {
 	return os.OpenFile(filepath.Join(dir, name), os.O_RDWR, os.FileMode(0644))
-}
-
-func syncDir(dir string) error {
-	f, err := os.Open(dir)
-	if err != nil {
-		return err
-	}
-	err = f.Sync()
-	closeErr := f.Close()
-	if err != nil {
-		return err
-	}
-	return closeErr
 }

--- a/fs/fs_nowasm.go
+++ b/fs/fs_nowasm.go
@@ -1,0 +1,26 @@
+//go:build !wasm
+
+package fs
+
+import (
+	"os"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+)
+
+func syncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	err = f.Sync()
+	closeErr := f.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+
+func prealloc(f *os.File, sizeInBytes int64, extendFile bool) error {
+	return fileutil.Preallocate(f, sizeInBytes, extendFile)
+}

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,12 +29,6 @@ func TestFS(t *testing.T) {
 	wf, err := fs.Create(tmpDir, "00001-abcd1234.wal", 512*1024)
 	require.NoError(t, err)
 	defer wf.Close()
-
-	// Should be pre-allocated (on supported file systems).
-	// TODO work out if this is reliable in CI or if we can detect supported FSs?)
-	info, err := os.Stat(filepath.Join(tmpDir, "00001-abcd1234.wal"))
-	require.NoError(t, err)
-	require.Equal(t, int64(512*1024), info.Size())
 
 	// Should be able to write data in any order
 	n, err := wf.WriteAt(bytes.Repeat([]byte{'2'}, 1024), 1024)
@@ -121,17 +115,17 @@ func TestRealFSNoDir(t *testing.T) {
 
 	_, err := fs.ListDir("/not-a-real-dir")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.Contains(t, strings.ToLower(err.Error()), "no such file or directory")
 
 	_, err = fs.Create("/not-a-real-dir", "foo", 1024)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.Contains(t, strings.ToLower(err.Error()), "no such file or directory")
 
 	_, err = fs.OpenReader("/not-a-real-dir", "foo")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.Contains(t, strings.ToLower(err.Error()), "no such file or directory")
 
 	_, err = fs.OpenWriter("/not-a-real-dir", "foo")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.Contains(t, strings.ToLower(err.Error()), "no such file or directory")
 }

--- a/fs/fs_wasm.go
+++ b/fs/fs_wasm.go
@@ -1,0 +1,16 @@
+//go:build wasm
+
+package fs
+
+import "os"
+
+func syncDir(dir string) error {
+	// TODO(asubiotto): Issue syncing dirs on wasm.
+	return nil
+}
+
+func prealloc(_ *os.File, _ int64, _ bool) error {
+	// fileutil.Prealloc relies on unix-only functionality which is unavailable
+	// on wasm.
+	return nil
+}

--- a/metadb/metadb_test.go
+++ b/metadb/metadb_test.go
@@ -6,11 +6,13 @@ package metadb
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/polarsignals/wal/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/polarsignals/wal/types"
 )
 
 func TestMetaDB(t *testing.T) {
@@ -86,7 +88,7 @@ func TestMetaDBErrors(t *testing.T) {
 	// Loading from a non-existent dir is an error
 	var db2 BoltMetaDB
 	_, err = db2.Load("fake-dir-that-does-not-exist")
-	require.ErrorContains(t, err, "no such file or directory")
+	require.True(t, strings.Contains(strings.ToLower(err.Error()), "no such file or directory"))
 }
 
 func makeState(nSegs int) *types.PersistentState {


### PR DESCRIPTION
This required abstracting some unix-only functionality and implementing a
non-bolt meta store. The wasm meta store is purposefully simple and not
production ready since we just need something to run tests with. Eventually,
we should remove bolt and use a simpler production-ready metastore since the
functionality Bolt was used for in the original repo is something we don't need
and have actually eliminated (arbitrary kv get/sets).